### PR TITLE
Fix margins on buttons

### DIFF
--- a/public/Button.scss
+++ b/public/Button.scss
@@ -1,3 +1,11 @@
 .icon{
 	margin-right: 0.5em;
 }
+
+//Apply margins to all buttons within the group
+.asdc-plugin-button-group {
+	.btn {
+		margin-right: 4px;
+		margin-top: 4px;
+	}
+}

--- a/public/OpenButton.jsx
+++ b/public/OpenButton.jsx
@@ -72,7 +72,7 @@ export default class OpenButton extends Component {
     //    <p>Task Status: {this.props.task.status}</p>
 
 		return (
-			<Fragment>
+			<div className="asdc-plugin-button-group">
         <DropdownButton
           id={"pipelinesDropdown"}
           bsStyle={"default"}
@@ -89,7 +89,7 @@ export default class OpenButton extends Component {
           bsSize={"small"}
           className={"pipeline-btn"}
         ><i className={"fab fa-python"} /> Open notebook</Button>
-			</Fragment>
+			</div>
 		);
 	}
 } 


### PR DESCRIPTION
Should in theory add the same margins as the top row. The reason why there was a gap before and not now is due to the <DropdownButton> having a margin, but not <Button>